### PR TITLE
Add save trajectory function

### DIFF
--- a/config/avia.yaml
+++ b/config/avia.yaml
@@ -51,3 +51,7 @@ pcd_save:
     pcd_save_en: false
     interval: -1                 # how many LiDAR frames saved in each pcd file; 
                                  # -1 : all frames will be saved in ONE pcd file, may lead to memory crash when having too much frames.
+
+trajectory_save:
+    traj_save_en: false
+    traj_file_path: "/home/catkin_ws/src/result/traj.txt" # You should enter absolute path.

--- a/config/horizon.yaml
+++ b/config/horizon.yaml
@@ -51,3 +51,7 @@ pcd_save:
     pcd_save_en: false
     interval: -1                 # how many LiDAR frames saved in each pcd file; 
                                  # -1 : all frames will be saved in ONE pcd file, may lead to memory crash when having too much frames.
+
+trajectory_save:
+    traj_save_en: false
+    traj_file_path: "/home/catkin_ws/src/result/traj.txt" # You should enter absolute path.

--- a/config/ouster64.yaml
+++ b/config/ouster64.yaml
@@ -51,3 +51,7 @@ pcd_save:
     pcd_save_en: false
     interval: -1                 # how many LiDAR frames saved in each pcd file; 
                                  # -1 : all frames will be saved in ONE pcd file, may lead to memory crash when having too much frames.
+
+trajectory_save:
+    traj_save_en: false
+    traj_file_path: "/home/catkin_ws/src/result/traj.txt" # You should enter absolute path.

--- a/config/velody16.yaml
+++ b/config/velody16.yaml
@@ -57,3 +57,7 @@ pcd_save:
     pcd_save_en: false
     interval: -1                 # how many LiDAR frames saved in each pcd file; 
                                  # -1 : all frames will be saved in ONE pcd file, may lead to memory crash when having too much frames.
+
+trajectory_save:
+    traj_save_en: false
+    traj_file_path: "/home/catkin_ws/src/result/traj.txt" # You should enter absolute path.

--- a/result/traj.txt
+++ b/result/traj.txt
@@ -1,0 +1,1 @@
+#timestamp x y z q_x q_y q_z q_w

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -731,7 +731,35 @@ void publish_path(const ros::Publisher pubPath)
         path.poses.emplace_back(msg_body_pose);
         pubPath.publish(path);
     }
-}        
+}
+
+/*
+* @brief : Save the whole trajectory to a txt file (TUM format)
+*/
+void save_trajectory(const std::string &traj_file) {
+    std::string filename(traj_file);
+    std::fstream output_fstream;
+
+    output_fstream.open(filename, std::ios_base::out);
+
+    if (!output_fstream.is_open()) {
+        std::cerr << "Failed to open " << filename << '\n';
+    }
+
+    else {
+        output_fstream << "#timestamp x y z q_x q_y q_z q_w" << std::endl;
+        for (const auto &p : path.poses) {
+            output_fstream << std::setprecision(15) << p.header.stamp.toSec() << " "
+                           << p.pose.position.x << " "
+                           << p.pose.position.y << " "
+                           << p.pose.position.z << " "
+                           << p.pose.orientation.x << " "
+                           << p.pose.orientation.y << " "
+                           << p.pose.orientation.z << " "
+                           << p.pose.orientation.w << std::endl;
+        }
+    }
+}
 
 int main(int argc, char** argv)
 {
@@ -1319,6 +1347,13 @@ int main(int argc, char** argv)
         status = ros::ok();
         rate.sleep();
     }
+
+    //--------------------------save trajectory----------------------------
+    if(traj_save_en){
+        save_trajectory(traj_save_path);
+        std::cout << "Save Point-LIO trajectory !!" << std::endl;  
+    }
+
     //--------------------------save map-----------------------------------
     /* 1. make sure you have enough memories
     /* 2. noted that pcd save will influence the real-time performences **/

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -28,6 +28,8 @@ bool   runtime_pos_log, pcd_save_en, path_en, extrinsic_est_en = true;
 bool   scan_pub_en, scan_body_pub_en;
 shared_ptr<Preprocess> p_pre;
 double time_diff_lidar_to_imu = 0.0;
+bool traj_save_en = false;
+std::string traj_save_path;
 
 void readParameters(ros::NodeHandle &nh)
 {
@@ -83,5 +85,7 @@ void readParameters(ros::NodeHandle &nh)
   nh.param<bool>("runtime_pos_log_enable", runtime_pos_log, 0);
   nh.param<bool>("pcd_save/pcd_save_en", pcd_save_en, false);
   nh.param<int>("pcd_save/interval", pcd_save_interval, -1);
+  nh.param<bool>("trajectory_save/traj_save_en", traj_save_en, false);
+  nh.param<std::string>("trajectory_save/traj_save_path", traj_save_path, "/home/catkin_ws/src/result/traj.txt");
 }
 

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -36,5 +36,7 @@ extern bool   runtime_pos_log, pcd_save_en, path_en;
 extern bool   scan_pub_en, scan_body_pub_en;
 extern shared_ptr<Preprocess> p_pre;
 extern double time_diff_lidar_to_imu;
+extern bool traj_save_en;
+extern std::string traj_save_path;
 
 void readParameters(ros::NodeHandle &n);


### PR DESCRIPTION
@Joanna-HE   
Thanks for your amazing work!  
I added a simple but necessary function to Point-LIO to save trajectories!  

The generated traj.txt is saved directly to the result folder and follows the TUM format,  
so it can be used directly with [evo](https://github.com/MichaelGrupp/evo) tool.  

The results of running Point-LIO on the M2DGR dataset, saving it to a traj.txt file,
and using the [evo](https://github.com/MichaelGrupp/evo) tool to compare it with the ground truth data are shown below.  

<p align="center"><img src="https://user-images.githubusercontent.com/41863759/226777725-9f0f5510-d7b0-4eac-b639-4010df5b4d92.png" width = "500" ></p>  

I'd be happy if this pull request is helpful and gets merged. :smile:   

